### PR TITLE
Modify Maven package command so it will complete.

### DIFF
--- a/zeppelin/overlays/zeppelin.Dockerfile
+++ b/zeppelin/overlays/zeppelin.Dockerfile
@@ -5,7 +5,7 @@ RUN \
   cd /incubator-zeppelin && \
   git checkout $ZEPPELIN_TAG
 WORKDIR /incubator-zeppelin
-RUN mvn package $ZEPPELIN_BUILD_ARGS &>/dev/null
+RUN mvn package -q $ZEPPELIN_BUILD_ARGS
 ENV ZEPPELIN_JAVA_OPTS "-Dspark.executor.home=/opt/$SPARK_DIRNAME"
 
 CMD ["bin/zeppelin.sh", "$ZEPPELIN_START_ARGS", "start"]


### PR DESCRIPTION
Previous version would quietly fail and not build anything, resulting in
an image that can't run Zeppelin.

Changing to use -q with mvn doesn't make it entirely silent, but the
overall run of `make -C zeppelin install` produces 2387 lines of output
on my machine, which should fit in the Travis CI output.